### PR TITLE
Require libopenssl1_1 for suse 15 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ root privileges to this script if you prefer
 
  Download links (One Click Install)
 
- * SLE 12 SP3 https://software.opensuse.org/ymp/home:megamaced:spotify-easyrpm/SLE_12_SP3/spotify-easyrpm.ymp?base=SUSE%3ASLE-12-SP3%3AGA&query=spotify-easyrpm
- * openSUSE 42.3 https://software.opensuse.org/ymp/home:megamaced:spotify-easyrpm/openSUSE_Leap_42.3/spotify-easyrpm.ymp?base=openSUSE%3ALeap%3A42.3&query=spotify-easyrpm
+ * SLE 15 https://software.opensuse.org/ymp/home:megamaced:spotify-easyrpm/openSUSE_Leap_15.0/spotify-easyrpm.ymp?base=openSUSE%3ALeap%3A15.0&query=spotify-easyrpm
  * openSUSE 15.0
  https://software.opensuse.org/ymp/home:megamaced:spotify-easyrpm/openSUSE_Leap_15.0/spotify-easyrpm.ymp?base=openSUSE%3ALeap%3A15.0&query=spotify-easyrpm
  * openSUSE Tumbleweed https://software.opensuse.org/ymp/home:megamaced:spotify-easyrpm/openSUSE_Tumbleweed/spotify-easyrpm.ymp?base=openSUSE%3AFactory&query=spotify-easyrpm

--- a/spotify-easyrpm
+++ b/spotify-easyrpm
@@ -58,7 +58,7 @@ cat <<EOF
 EOF
 sleep 2
 cat <<EOF
-VERSION: 1.1.4
+VERSION: 1.1.5
 SUPPORT: https://github.com/megamaced/spotify-easyrpm/issues
 The latest openSUSE Leap, Tumbleweed or SLE are supported only
 

--- a/spotify-easyrpm
+++ b/spotify-easyrpm
@@ -58,7 +58,7 @@ cat <<EOF
 EOF
 sleep 2
 cat <<EOF
-VERSION: 1.1.5
+VERSION: 1.1.5b
 SUPPORT: https://github.com/megamaced/spotify-easyrpm/issues
 The latest openSUSE Leap, Tumbleweed or SLE are supported only
 
@@ -508,7 +508,11 @@ Requires: mozilla-nss
 Requires: libudev1
 Requires: libX11-6
 Requires: libXtst6
+%if 0%{?sle_version} <= 150000 && 0%{?is_opensuse} || 0%{?sle_version} <= 150000 && !0%{?is_opensuse}
+Requires: libopenssl1_0_0
+%else
 Requires: libopenssl1_1
+%endif
 Requires: xdg-utils
 Recommends: libavcodec56
 Recommends: libavformat56

--- a/spotify-easyrpm
+++ b/spotify-easyrpm
@@ -58,7 +58,7 @@ cat <<EOF
 EOF
 sleep 2
 cat <<EOF
-VERSION: 1.1.5b
+VERSION: 1.1.5
 SUPPORT: https://github.com/megamaced/spotify-easyrpm/issues
 The latest openSUSE Leap, Tumbleweed or SLE are supported only
 

--- a/spotify-easyrpm
+++ b/spotify-easyrpm
@@ -498,6 +498,7 @@ Source:   %{name}-%{version}.tar.gz
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  update-desktop-files
 Requires: libasound2
+Requires: libatomic1
 Requires: libcurl4
 Requires: gconf2
 Requires: libgtk-2_0-0
@@ -507,7 +508,8 @@ Requires: mozilla-nss
 Requires: libudev1
 Requires: libX11-6
 Requires: libXtst6
-Requires: libopenssl1_0_0
+Requires: libopenssl1_1
+Requires: xdg-utils
 Recommends: libavcodec56
 Recommends: libavformat56
 Recommends: zenity


### PR DESCRIPTION
Require libopenssl1_1 for suse 15 and above - mostly fixing SLE 15 which doesn't have libopenssl1_0_0 in the main repos