### PR TITLE
fix --no-gpg-checks flag for zypper install

### DIFF
--- a/spotify-easyrpm
+++ b/spotify-easyrpm
@@ -446,7 +446,7 @@ fi
 
 f_rpm_install() {
 echo "Installing ${V_PKGNAME}-${V_DEB_VER}"
-if ! sudo zypper --non-interactive --no-gpg-check in "${V_RPMS_DIR}"/"${V_RPM_ARCH}"/"${V_PKGNAME}"-"${V_DEB_VER}"*"${V_RPM_ARCH}".rpm; then
+if ! sudo zypper --non-interactive --no-gpg-checks in "${V_RPMS_DIR}"/"${V_RPM_ARCH}"/"${V_PKGNAME}"-"${V_DEB_VER}"*"${V_RPM_ARCH}".rpm; then
   f_error "Failed to install ${V_PKGNAME}-${V_DEB_VER}"
 fi
 }


### PR DESCRIPTION
this PR will fix #27, successfully tested for Opensuse Tumbleweed

set the gpg flag for no gpg check as described in the manual page of zypper:

> Repository Options:
>        --no-gpg-checks
>            Ignore GPG check failures and continue. If a GPG issue occurs when using this option zypper prints and
>            logs a warning and automatically continues without interrupting the operation. Use this option with
>            caution, as you can easily overlook security problems by using it. (see section GPG checks)