### PR TITLE
fix: Stop handling /usr/share/doc, which is no longer included in the snap package

### DIFF
--- a/spotify-easyrpm
+++ b/spotify-easyrpm
@@ -209,10 +209,9 @@ fi
 f_extract_snap() {
 echo "Extracting snap and preparing"
 unsquashfs -d "${V_SNAP_EXTRACT_DIR}"  "${V_SOURCES_DIR}"/"${V_HTTP_SNAP}" || f_error "Failed to extract snap"
-mkdir -p "${V_SOURCES_DIR}"/"${V_PKGNAME}"/usr/{share/applications,share/doc,bin}
+mkdir -p "${V_SOURCES_DIR}"/"${V_PKGNAME}"/usr/{share/applications,bin}
 mv "${V_SNAP_EXTRACT_DIR}"/usr/share/spotify "${V_SOURCES_DIR}"/"${V_PKGNAME}"/usr/share
 mv "${V_SNAP_EXTRACT_DIR}"/usr/bin/spotify "${V_SOURCES_DIR}"/"${V_PKGNAME}"/usr/bin
-mv "${V_SNAP_EXTRACT_DIR}"/usr/share/doc/"${V_PKGNAME}" "${V_SOURCES_DIR}"/"${V_PKGNAME}"/usr/share/doc
 }
 
 
@@ -467,7 +466,6 @@ fi
 %dir %{_datadir}/spotify
 %{_datadir}/spotify/*
 %{_datadir}/applications/spotify.desktop
-%{_datadir}/doc/${V_PKGNAME}/*
 %{_bindir}/spotify
 EOF
 }


### PR DESCRIPTION
Fixes https://github.com/megamaced/spotify-easyrpm/issues/57